### PR TITLE
Allow to retrieve last error

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -16,6 +16,7 @@ class Client
     protected $apiKey;
     protected $apiEndpoint = 'https://%dc%.api.mailchimp.com/3.0/';
     protected $headers = [];
+    protected $lastError;
 
     public function __construct($apiKey)
     {
@@ -85,8 +86,12 @@ class Client
                     break;
             }
 
+            $this->lastError = null;
+
             return $response;
         } catch (RequestException $e) {
+            $this->lastError = json_decode($e->getResponse()->getBody());
+
             return $e->getResponse();
         }
     }
@@ -271,5 +276,13 @@ class Client
     public function getSubscriberHash($email)
     {
         return md5(strtolower($email));
+    }
+
+    /**
+     * @return object|null
+     */
+    public function getLastError()
+    {
+        return $this->lastError;
     }
 }


### PR DESCRIPTION
Currently when using `oneup/mailchimp-api-v3` it is not really possible to receive detailed error messages from Mailmhimp. For example, if you use the `subscribeToList` method, Mailmhimp might response with something like this in its response:

```json
{
  "type": "https://mailchimp.com/developer/marketing/docs/errors/",
  "title": "Invalid Resource",
  "status": 400,
  "detail": "Your merge fields were invalid.",
  "instance": "8cf2c011-a212-9b3a-6c51-a4d631a124b4",
  "errors": [
    {
      "field": "VORNAME",
      "message": "Please enter a value"
    },
    {
      "field": "NACHNAME",
      "message": "Please enter a value"
    }
  ]
}
```

i.e. telling you that the merge fields you submitted are wrong and which ones and why.

This PR would always save the JSON encoded body of the non-200 responses as the last error so that you can retrieve it from the outside.