### PR TITLE
Throw error if there is no response

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -96,9 +96,9 @@ class Client
                 throw $e;
             }
 
-            $this->lastError = json_decode($e->getResponse()->getBody());
+            $this->lastError = json_decode($response->getBody());
 
-            return $e->getResponse();
+            return $response;
         }
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -90,6 +90,12 @@ class Client
 
             return $response;
         } catch (RequestException $e) {
+            $response = $e->getResponse();
+
+            if (null === $response) {
+                throw $e;
+            }
+
             $this->lastError = json_decode($e->getResponse()->getBody());
 
             return $e->getResponse();


### PR DESCRIPTION
There can be no response if there is a `RequestException`. In this case I think the error should just be thrown.