### PR TITLE
Remove apikey from query parameters

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -43,8 +43,6 @@ class Client
 
     public function call($type = 'get', $uri = '', $args = [], $timeout = 10): ?ResponseInterface
     {
-        $args['apikey'] = $this->apiKey;
-
         try {
             switch ($type) {
                 case 'post':


### PR DESCRIPTION
Received an e-mail from Mailchimp today stating the following:

> We’re writing to let you know about a change that we’re making to our API that will affect an integration you use. We want you to know more about this change and how it may impact you, as well as next steps you should take.

> **What’s changing**
On August 8, we will stop allowing integrations to pass API keys in query parameters for API authentication.

> For context, you can think of an API as a way for different apps to talk to one another. You send and receive data between apps using API requests and responses. An API key is a unique series of characters—similar to a password—that’s included in a request to verify that the requesting system is allowed to communicate with the receiving system. For this reason, it is very important to maintain best security practices with API keys.

> Passing keys in query parameters poses a security risk because the API key can be stored in your browser history, which could give unauthorized access to the API key if someone uses your computer or otherwise has access to your browser history.

> **What you need to do**
Before August 8, you’ll need to ensure all integrations in your account don’t pass API keys through query parameters. 

> **If you use a custom integration**
Before August 8, you or your developer will need to ensure your custom integration is updated to use HTTP basic authentication or bearer authentication.

> If you do not update your integration, you will get a 401 error with the title “API Key Invalid,” and message, “Your request did not include an API key,” when trying to authenticate an action by sending an API key in query parameters.

The `apikey` argument has been redundant in this library for years so we can just remove it. I did and tested subscribing and unsubscribing from the API successfully.